### PR TITLE
🩹 fix : 코드 수정

### DIFF
--- a/src/main/java/com/example/oner/dto/list/ListRequestDto.java
+++ b/src/main/java/com/example/oner/dto/list/ListRequestDto.java
@@ -7,6 +7,9 @@ import lombok.Getter;
 @Getter
 public class ListRequestDto {
 
+    @NotNull(message = "워크스페이스 ID는 필수 입니다.")
+    private Long workspaceId;
+
     @NotNull(message = "보드 ID는 필수 입니다.")
     private Long boardId;
 
@@ -16,7 +19,8 @@ public class ListRequestDto {
     private int positionList;
 
 
-    public ListRequestDto(Long boardId, String listTitle, int positionList) {
+    public ListRequestDto(Long workspaceId, Long boardId, String listTitle, int positionList) {
+        this.workspaceId = workspaceId;
         this.boardId = boardId;
         this.listTitle = listTitle;
         this.positionList = positionList;

--- a/src/main/java/com/example/oner/error/errorcode/ErrorCode.java
+++ b/src/main/java/com/example/oner/error/errorcode/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
     MESSAGE_SENDING_ERROR(BAD_REQUEST,"message send error"),
     DUPLICATE_POSITION_LIST(BAD_REQUEST, "중복된 position 입니다."),
     INVITED_MEMBER(BAD_REQUEST, "멤버로 초대된 유저입니다."),
+    INVALID_REQUEST(BAD_REQUEST, "[필수값 누락] 보드 제목을 입력해주세요."),
 
 
     /* 401 UNAUTHORIZED : 인증되지 않은 사용자 */

--- a/src/main/java/com/example/oner/repository/MemberRepository.java
+++ b/src/main/java/com/example/oner/repository/MemberRepository.java
@@ -19,6 +19,9 @@ import java.util.Optional;
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
+    @Query("SELECT m FROM Member m WHERE m.user.id = :userId AND m.workspace.id = :workspaceId AND m.role = 'BOARD'")
+    Optional<Member> findByUserIdAndWorkspaceIdAndRole(@Param("userId") Long userId, @Param("workspaceId") Long workspaceId);
+
     Optional<Member> findByUserIdAndWorkspaceId(Long userId, Long workspaceId);
 
     Optional<Object> findByUserIdAndWorkspaceIdAndWait(Long id, Long workspaceId, MemberWait memberWait);

--- a/src/main/java/com/example/oner/service/BoardService.java
+++ b/src/main/java/com/example/oner/service/BoardService.java
@@ -38,12 +38,17 @@ public class BoardService {
         // 인증 객체를 이용해 로그인한 사용자 정보 가져오기
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         UserDetailsImpl userDetails = (UserDetailsImpl) authentication.getPrincipal();
-        User user = userDetails.getUser();      // 로그인 유저 조회
-        Member member = user.getMember();   // 로그인한 유저의 첫번째 멤버 조회
+        User user = userDetails.getUser();
+        Member member = user.getMember();
 
         // 워크스페이스 조회
         Workspace workspace = workspaceRepository.findByIdAndMembersContaining(requestDto.getWorkspaceId(), member)
                 .orElseThrow(() -> new CustomException(ErrorCode.WORKSPACE_NOT_FOUND));
+
+        // 보드 제목이 비어 있는 경우
+        if (requestDto.getTitle() == null || requestDto.getTitle().trim().isEmpty()) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
 
         // 멤버 권한 확인
         if (!member.hasPermission(MemberRole.BOARD)) {


### PR DESCRIPTION
<img width="827" alt="image" src="https://github.com/user-attachments/assets/86d82ff8-78e9-421e-8d14-c9db75c4e641" />

멤버 role 권한이 "BOARD" 와 "READ" 가 있을 경우 List 생성 불가 
-> 이유: 데이터베이스 테이블에서 동일한 user_id와 workspace_id가  존재, role 권한이 다른 상태로 저장되어 있음
쿼리가 단일 결과를 반환해야 하는 상황에서 여러 결과가 반환되어 IncorrectResultSizeDataAccessException 에러가 발생됨.

ListService 리스트 생성시 특정 멤버 role 권한 확인 메서드 추가
-> "BOARD" 권한인 멤버만을 불러화 리스트 생성이 가능해짐